### PR TITLE
Add a prototype blog (aka support Page objects)

### DIFF
--- a/Kroeg.Client/js/SessionObjects.ts
+++ b/Kroeg.Client/js/SessionObjects.ts
@@ -9,7 +9,7 @@ export class SessionObjects {
         this.regenerate();
     }
 
-    private static _placeholders: string[] = ["newnote"];
+    private static _placeholders: string[] = ["newnote", "newpage"];
 
     public regenerate() {
         let navbar: {id: string, loggedInAs?: string} = {

--- a/Kroeg.Client/js/TemplateService.ts
+++ b/Kroeg.Client/js/TemplateService.ts
@@ -197,13 +197,20 @@ export class TemplateRenderer {
         }
 
         if (render) {
+            let text = "";
             for (let content of item.children) {
-                if (content.type == TemplateItemType.Text)
-                    element.insertAdjacentHTML('beforeend', content.data);
-                else if (content.type == TemplateItemType.Script)
-                    element.insertAdjacentHTML('beforeend', this._parse(content, data, regs, false));
+                if (content.type == TemplateItemType.Text || content.type == TemplateItemType.Script) {
+                    if (content.type == TemplateItemType.Text)
+                        text += content.data;
+                    else if (content.type == TemplateItemType.Script)
+                        text += this._parse(content, data, regs, false);
+                }
                 else
                 {
+                    if (text.length > 0) {
+                        element.insertAdjacentHTML("beforeend", text);
+                        text = "";
+                    }
                     if ("x-for-in" in content.arguments) {
                         let resultItems = this._parse(content.arguments["x-for-in"][0], data, regs, true) as any[];
                         let prevItem = regs.item;
@@ -224,6 +231,11 @@ export class TemplateRenderer {
 
                     element.appendChild(this._render(content, data, regs, renderResult, true));
                 }
+            }
+
+            if (text.length > 0) {
+                element.insertAdjacentHTML("beforeend", text);
+                text = "";
             }
         }
 

--- a/Kroeg.Server/Services/Template/TemplateParser.cs
+++ b/Kroeg.Server/Services/Template/TemplateParser.cs
@@ -39,7 +39,7 @@ namespace Kroeg.Server.Services.Template
                 var after = data.IndexOf("}}", next);
                 
                 if (next != start)
-                    items.Add(new TemplateItem { Type = alwaysScript ? TemplateItemType.Script : TemplateItemType.Text, Data = data.Substring(start, next - start - 1) });
+                    items.Add(new TemplateItem { Type = alwaysScript ? TemplateItemType.Script : TemplateItemType.Text, Data = data.Substring(start, next - start) });
                 items.Add(new TemplateItem { Type = TemplateItemType.Script, Data = data.Substring(next + 2, after - next - 2)});
 
                 start = after + 2;

--- a/Kroeg.Server/Services/Template/TemplateService.cs
+++ b/Kroeg.Server/Services/Template/TemplateService.cs
@@ -80,7 +80,7 @@ namespace Kroeg.Server.Services.Template
             private static Regex _disallowed_nodes = new Regex("^(script|object|embed)$");
 
 
-            public string escape(string data)
+            public string sanitize(string data)
             {
                 return data.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;");
             }

--- a/Kroeg.Server/templates/body.html
+++ b/Kroeg.Server/templates/body.html
@@ -1,6 +1,7 @@
 <div class="container" style="padding-top: 25px">
     <div x-if="AS.containsAny('type', ['Collection', 'OrderedCollection'])" x-render="collection/full"></div>
     <div x-if="AS.containsAny('type', ['CollectionPage', 'OrderedCollectionPage'])" x-render="collection/page"></div>
-    <div x-if="!AS.containsAny('type', ['Collection', 'CollectionPage', 'OrderedCollection', 'OrderedCollectionPage'])" x-render="object"></div>
+    <div x-if="AS.contains('type', 'Page')" x-render="full/page"></div>
+    <div x-if="!AS.containsAny('type', ['Collection', 'CollectionPage', 'OrderedCollection', 'OrderedCollectionPage', 'Page'])" x-render="object"></div>
     <small>Kroeg pre-alpha - This page has been rendered on the <span x-if="Renderer.server">Server</span><span x-if="Renderer.client">Client</span></small>
 </div>

--- a/Kroeg.Server/templates/client/newpage.html
+++ b/Kroeg.Server/templates/client/newpage.html
@@ -1,0 +1,41 @@
+<div>
+    <h1>New page</h1>
+
+    <form data-component="form" data-endpoint="{{Renderer.loggedInAs.outbox}}">
+        <input type="hidden" name="type" value="Page" />
+        <div class="form-group">
+            <label for="_name">Name:</label>
+            <input type="text" class="form-control" name="name" id="_name" />
+        </div>
+        <div class="form-group">
+            <label for="_summary">Summary:</label>
+            <input type="text" class="form-control" name="summary" id="_summary" />
+            <label class="form-check-label">
+                <input type="checkbox" class="form-check-input" name="sensitive.bool" value="true">
+                Sensitive
+            </label>
+        </div>
+        <div class="form-group">
+            <label for="_content">Content:</label>
+            <div class="form-control" data-component="wysiwyg" data-placeholder="Enter your content here" data-name="content" id="_content"></textarea>
+        </div>
+        <div class="form-group">
+            <label for="_taggyTo">Send to:</label>
+            <div class="kroeg-taggy form-control" data-component="userpicker" data-name="to"><span class="kroeg-taggy-tags"></span><div class="kroeg-taggy-input"><input type="text" id="_taggyTo" value="" /></div></div>
+            <label class="form-check-label">
+                <input type="checkbox" class="form-check-input" name="to" value="https://www.w3.org/ns/activitystreams#Public">
+                Also send publicly
+            </label>
+        </div>
+        <div class="form-group">
+            <label for="_taggyCC">CC these people:</label>
+            <div class="kroeg-taggy form-control" data-component="userpicker" data-name="cc"><span class="kroeg-taggy-tags"></span><div class="kroeg-taggy-input"><input type="text" id="_taggyCC" value="" /></div></div>
+            <label class="form-check-label">
+                <input type="checkbox" class="form-check-input" name="to" value="https://www.w3.org/ns/activitystreams#Public">
+                Also CC publicly
+            </label>
+        </div>
+
+        <input type="submit" value="Submit" class="btn btn-primary" />
+    </form>
+</div>

--- a/Kroeg.Server/templates/client/object.html
+++ b/Kroeg.Server/templates/client/object.html
@@ -1,3 +1,4 @@
 <div>
     <div x-render="client/newnote" x-if="{{AS.take('id') == 'kroeg:newnote'}}"></div>
+    <div x-render="client/newpage" x-if="{{AS.take('id') == 'kroeg:newpage'}}"></div>
 </div>

--- a/Kroeg.Server/templates/full/page.html
+++ b/Kroeg.Server/templates/full/page.html
@@ -1,0 +1,10 @@
+<div class="row" style="padding-left: 58px; position: relative">
+    <div class="col-md-12">
+        <div x-render="objects/sub/user_header" x-render-id="AS.take('attributedTo')"></div>
+        <a href="{{AS.take('id')}}"><small>at {{AS.take('published')}}</small></a>
+    </div>
+    <div class="col-md-12">
+        <h1>{{Renderer.sanitize(AS.take('name'))}}</h1>
+        {{Renderer.clean(AS.take('content'))}}
+    </div>
+</div>

--- a/Kroeg.Server/templates/objects/header/object.html
+++ b/Kroeg.Server/templates/objects/header/object.html
@@ -1,5 +1,6 @@
 <div class="col-md-12 nopad">
 		<div x-render="objects/header/note" x-if="AS.contains('type', 'Note')"></div>
+		<div x-render="objects/header/page" x-if="AS.contains('type', 'Page')"></div>
 		<div x-render="objects/header/user" x-if="AS.contains('type', 'Person')"></div>
 		<span x-if="!AS.containsAny('type', ['Note', 'Person'])">{{AS.take('id')}}</span>
 </div>

--- a/Kroeg.Server/templates/objects/header/page.html
+++ b/Kroeg.Server/templates/objects/header/page.html
@@ -1,0 +1,11 @@
+﻿<div class="row" style="padding-left: 58px; position: relative">
+<div class="col-md-12">
+	<div x-render="objects/sub/user_header" x-render-id="AS.take('attributedTo')"></div>
+	<a href="{{AS.take('id')}}"><small>at {{AS.take('published')}}</small></a>
+</div>
+<div class="col-md-12">
+	<a href="{{AS.take('id')}}"><h1>{{AS.take('name')}}</h1></a>
+	{{Renderer.sanitize(AS.take('summary'))}}
+	<emph x-if="AS.take('sensitive', false)">(Warning: marked as sensitive)</emph>
+</div>
+</div>

--- a/Kroeg.Server/templates/objects/no-header/object.html
+++ b/Kroeg.Server/templates/objects/no-header/object.html
@@ -1,5 +1,6 @@
-<div class="col-md-12">
+<div class="col-md-12 nopad">
 		<div x-render="objects/no-header/note" x-if="AS.contains('type', 'Note')"></div>
+		<div x-render="objects/no-header/page" x-if="AS.contains('type', 'Page')"></div>
 		<div x-render="objects/header/user" x-if="AS.contains('type', 'Person')"></div>
-		<span x-if="!AS.containsAny('type', ['Note', 'Person'])">{{AS.take('id')}}</span>
+		<span x-if="!AS.containsAny('type', ['Note', 'Person', 'Page'])">{{AS.take('id')}}</span>
 </div>

--- a/Kroeg.Server/templates/objects/no-header/page.html
+++ b/Kroeg.Server/templates/objects/no-header/page.html
@@ -1,0 +1,5 @@
+﻿<div class="col-md-12 nopad">
+	<a href="{{AS.take('id')}}"><h1>{{AS.take('name')}}</h1></a>
+	{{Renderer.sanitize(AS.take('summary'))}}
+	<emph x-if="AS.take('sensitive', false)">(Warning: marked as sensitive)</emph>
+</div>


### PR DESCRIPTION
- Adds a (hidden) kroeg:newpage pseudo-object
- Fixes issue with spacing between text elements
- Pages in collections are just name/summary
- Full page page is the (cleaned) contents of the page.